### PR TITLE
add data-content attribute for matomo tracking

### DIFF
--- a/admin/class-wp-sponsors-admin.php
+++ b/admin/class-wp-sponsors-admin.php
@@ -141,6 +141,10 @@ class WP_Sponsors_Admin {
 			update_post_meta( $post_id, 'wp_sponsors_desc', $_POST['wp_sponsors_desc'] );
 		}
 
+		if ( isset( $_POST['_data_content'] ) ) {
+			update_post_meta( $post_id, '_data_content', $_POST['_data_content'] );
+		}
+
 		$link_behaviour = isset($_POST['wp_sponsor_link_behaviour']) ? '1' : '0';
 		update_post_meta( $post_id, 'wp_sponsor_link_behaviour', $link_behaviour );
 	}

--- a/admin/partials/meta-boxes/sponsor-info.php
+++ b/admin/partials/meta-boxes/sponsor-info.php
@@ -19,6 +19,11 @@ $meta_value = get_post_meta( get_the_ID(), '_email', true );
 echo '<p class="post-attributes-label-wrapper"><label for="wp_sponosrs_email" class="post-attributes-label">' . __( 'Email', 'wp-sponsors' ) . '</label></p>';
 echo '<input type="email" id="wp_sponosrs_email" name="_email" value="' . $meta_value . '" class="widefat" />';
 
+// Get the data-content data if its already been entered
+$meta_value = get_post_meta( get_the_ID(), '_data_content', true );
+// Checks and displays the retrieved value
+echo '<p class="post-attributes-label-wrapper"><label for="wp_sponosrs_data_content" class="post-attributes-label">' . __( 'data-content', 'wp-sponsors' ) . '</label></p>';
+echo '<input type="text" id="wp_sponosrs_data_content" name="_data_content" value="' . $meta_value . '" class="widefat" />';
 
 // Display code/markup goes here. Don't forget to include nonces!
 // Noncename needed to verify where the data originated

--- a/includes/class-wp-sponsors-shortcodes.php
+++ b/includes/class-wp-sponsors-shortcodes.php
@@ -47,6 +47,11 @@ class WP_Sponsors_Shortcodes {
 			</div>
 
 			<div class="wp-sponsors-form-field">
+				<label for="wp_sponsors_data_content"><?php esc_html_e( 'Content tracking attribute', 'wp-sponsors' ); ?></label>
+				<input id="wp_sponsors_data_content" type="text" name="wp_sponsors_form[data_content]" placeholder="<?php esc_attr_e( 'data-content', 'wp-sponsors' ); ?>">
+			</div>
+
+			<div class="wp-sponsors-form-field">
 				<label for="wp_sponsors_desc"><?php esc_html_e( 'Sponsor Description', 'wp-sponsors' ); ?></label>
 				<textarea id="wp_sponsors_desc" name="wp_sponsors_form[desc]" placeholder="<?php esc_attr_e( 'Description', 'wp-sponsors' ); ?>"></textarea>
 			</div>
@@ -158,13 +163,16 @@ class WP_Sponsors_Shortcodes {
 				$link = get_post_meta( $sponsor_post->ID, 'wp_sponsors_url', true );
 			}
 
-			$sponsor                = array();
-			$sponsor['id']          = $sponsor_post->ID;
-			$sponsor['link']        = $link;
-			$sponsor['link_target'] = get_post_meta( $sponsor_post->ID, 'wp_sponsor_link_behaviour', true );
-			$sponsor['logo']        = get_the_post_thumbnail( $sponsor_post->ID, $atts['image_size'] );
-			$sponsor['title']       = get_the_title( $sponsor_post );
-			$sponsor['categories']  = get_the_terms( $sponsor_post, 'sponsor_categories');
+			$data_content = get_post_meta( $sponsor_post->ID, '_data_content', true );
+
+			$sponsor                 = array();
+			$sponsor['id']           = $sponsor_post->ID;
+			$sponsor['link']         = $link;
+			$sponsor['link_target']  = get_post_meta( $sponsor_post->ID, 'wp_sponsor_link_behaviour', true );
+			$sponsor['logo']         = get_the_post_thumbnail( $sponsor_post->ID, $atts['image_size'] );
+			$sponsor['title']        = get_the_title( $sponsor_post );
+			$sponsor['categories']   = get_the_terms( $sponsor_post, 'sponsor_categories');
+			$sponsor['data_content'] = $data_content;
 			$desc = do_shortcode( wpautop( $sponsor_post->post_content ) );
 			if ( ! $desc ) {
 				$desc = get_post_meta( $sponsor_post->ID, 'wp_sponsors_desc', true );
@@ -266,7 +274,7 @@ class WP_Sponsors_Shortcodes {
                 );*/
 				$style['containerPre'] = '<div id="wp-sponsors" class="clearfix slider wp-sponsors ' . $atts['slider_image'] . ' ' . ( 1 === absint( $atts['verticalcenter'] ) ? 'vertical-center' : '' ) . '" data-slick="' . esc_attr( wp_json_encode( $slickSettings ) ) . '">';
 				$style['containerPost'] = '</div>';
-				$style['wrapperClass'] = 'sponsor-item';
+				$style['wrapperClass'] = 'sponsor-item ';
 				$style['wrapperPre'] = 'div';
 				$style['wrapperPost'] = '</div>';
 				break;
@@ -286,7 +294,7 @@ class WP_Sponsors_Shortcodes {
 					$link        = $sponsor['link'];
 					$link_target = $sponsor['link_target'];
 					$target      = 1 === absint( $link_target ) ? 'target="_blank"' : '';
-					$class       = '';
+					$class       =  $sponsor['data-content'] . ' ';
 					$class       .= $atts['size'];
 
 					if ( $sponsor['categories'] ) {

--- a/includes/class-wp-sponsors-widget.php
+++ b/includes/class-wp-sponsors-widget.php
@@ -79,7 +79,7 @@ class WP_Sponsors_Widget extends WP_Widget {
 				$image        = $use_image ? get_the_post_thumbnail( get_the_ID(), $image_size ) : '';
 				$categories   = get_the_terms( get_the_ID(), 'sponsor_categories' );
 				$data_content = get_post_meta( get_the_ID(), '_data_content', true );
-                $data_content_attr = ( strlen($data_content ) > 0) ? ' data-content="' . $data_content . '" ' : '';
+                $data_content_attr = ( strlen($data_content ) > 0) ? ' data-track-content data-content-name="' . $data_content . '" ' : '';
 				$classes      = $sponsorStyling . ' 1a';
 				if ( $categories ) {
 					$category_slugs = wp_list_pluck( $categories, 'slug' );

--- a/includes/class-wp-sponsors-widget.php
+++ b/includes/class-wp-sponsors-widget.php
@@ -72,19 +72,21 @@ class WP_Sponsors_Widget extends WP_Widget {
 				if ( ! $link ) {
 					$link = get_post_meta( get_the_ID(), 'wp_sponsors_url', true );
 				}
-				$link_target = get_post_meta( get_the_ID(), 'wp_sponsor_link_behaviour', true );
-				$target      = ( $link_target == 1 OR $widget_target == true ) ? true : false;
-				$use_image   = isset( $instance['check_images'] ) && 'on' === $instance['check_images'] ? true : false;
-				$use_title   = isset( $instance['show_title'] ) && 'on' === $instance['show_title'] ? true : false;
-				$image       = $use_image ? get_the_post_thumbnail( get_the_ID(), $image_size ) : '';
-				$categories  = get_the_terms( get_the_ID(), 'sponsor_categories' );
-				$classes     = $sponsorStyling;
+				$link_target  = get_post_meta( get_the_ID(), 'wp_sponsor_link_behaviour', true );
+				$target       = ( $link_target == 1 OR $widget_target == true ) ? true : false;
+				$use_image    = isset( $instance['check_images'] ) && 'on' === $instance['check_images'] ? true : false;
+				$use_title    = isset( $instance['show_title'] ) && 'on' === $instance['show_title'] ? true : false;
+				$image        = $use_image ? get_the_post_thumbnail( get_the_ID(), $image_size ) : '';
+				$categories   = get_the_terms( get_the_ID(), 'sponsor_categories' );
+				$data_content = get_post_meta( get_the_ID(), '_data_content', true );
+                $data_content_attr = ( strlen($data_content ) > 0) ? ' data-content="' . $data_content . '" ' : '';
+				$classes      = $sponsorStyling . ' 1a';
 				if ( $categories ) {
 					$category_slugs = wp_list_pluck( $categories, 'slug' );
 					$classes .= ' ' . implode( ' ', $category_slugs );
 				}
 				?>
-                <li class="<?php echo esc_attr( $classes ); ?>">
+                <li class="<?php echo esc_attr( $classes );?>" <?php echo $data_content_attr; ?>>
                     <?php
                     if ( $link ) {
                         ?>

--- a/includes/class-wp-sponsors-widget.php
+++ b/includes/class-wp-sponsors-widget.php
@@ -79,7 +79,7 @@ class WP_Sponsors_Widget extends WP_Widget {
 				$image        = $use_image ? get_the_post_thumbnail( get_the_ID(), $image_size ) : '';
 				$categories   = get_the_terms( get_the_ID(), 'sponsor_categories' );
 				$data_content = get_post_meta( get_the_ID(), '_data_content', true );
-                $data_content_attr = ( strlen($data_content ) > 0) ? ' data-track-content data-content-name="' . $data_content . '" ' : '';
+                $data_content_attr = ( strlen($data_content ) > 0) ? ' data-track-content data-content-name="sponsor" data-content-piece="' . $data_content . '" ' : '';
 				$classes      = $sponsorStyling . ' 1a';
 				if ( $categories ) {
 					$category_slugs = wp_list_pluck( $categories, 'slug' );

--- a/includes/class-wp-sponsors-widget.php
+++ b/includes/class-wp-sponsors-widget.php
@@ -80,7 +80,7 @@ class WP_Sponsors_Widget extends WP_Widget {
 				$categories   = get_the_terms( get_the_ID(), 'sponsor_categories' );
 				$data_content = get_post_meta( get_the_ID(), '_data_content', true );
                 $data_content_attr = ( strlen($data_content ) > 0) ? ' data-track-content data-content-name="sponsor" data-content-piece="' . $data_content . '" ' : '';
-				$classes      = $sponsorStyling . ' 1a';
+				$classes      = $sponsorStyling;
 				if ( $categories ) {
 					$category_slugs = wp_list_pluck( $categories, 'slug' );
 					$classes .= ' ' . implode( ' ', $category_slugs );


### PR DESCRIPTION
This adds a data-content="some text" attribute management for every sponsor.

data-content is useful when using matomo for analytics

EDIT: this PR against upstream was actually a mistake, I wanted to make it against my fork to start with. But now that mistake is done, I changed it to a draft... About the content itself, given this is only useful for matomo users, I'm not sure this change is appropriate to include as is. 